### PR TITLE
Hide forgot password link if basic auth enabled

### DIFF
--- a/app/src/Root.tsx
+++ b/app/src/Root.tsx
@@ -110,7 +110,12 @@ export default function Root({
 				<Wrapper>
 					<Switch>
 						<Route path="/app" exact>
-							<Login urlProps={urlProps} />
+							<Login
+								urlProps={urlProps}
+								isBasicAuthenticationDisabled={
+									(globalState.is_basic_authentication_disabled as any) === 'true'
+								}
+							/>
 						</Route>
 						<Route path="/app/signup">
 							<SignUp urlProps={urlProps} />

--- a/app/src/pages/login.tsx
+++ b/app/src/pages/login.tsx
@@ -29,7 +29,13 @@ const FooterContent = styled.div`
 	margin-top: 10px;
 `;
 
-export default function Login({ urlProps }: { urlProps: Record<string, any> }) {
+export default function Login({
+	urlProps,
+	isBasicAuthenticationDisabled,
+}: {
+	urlProps: Record<string, any>;
+	isBasicAuthenticationDisabled: boolean;
+}) {
 	const { config } = useAuthorizer();
 	const [view, setView] = useState<VIEW_TYPES>(VIEW_TYPES.LOGIN);
 	return (
@@ -47,13 +53,15 @@ export default function Login({ urlProps }: { urlProps: Record<string, any> }) {
 						<AuthorizerMagicLinkLogin urlProps={urlProps} />
 					)}
 					<Footer>
-						<Link
-							to="#"
-							onClick={() => setView(VIEW_TYPES.FORGOT_PASSWORD)}
-							style={{ marginBottom: 10 }}
-						>
-							Forgot Password?
-						</Link>
+						{!isBasicAuthenticationDisabled && (
+							<Link
+								to="#"
+								onClick={() => setView(VIEW_TYPES.FORGOT_PASSWORD)}
+								style={{ marginBottom: 10 }}
+							>
+								Forgot Password?
+							</Link>
+						)}
 					</Footer>
 				</Fragment>
 			)}

--- a/server/handlers/app.go
+++ b/server/handlers/app.go
@@ -72,6 +72,14 @@ func AppHandler() gin.HandlerFunc {
 			c.JSON(400, gin.H{"error": "failed to get organization logo"})
 			return
 		}
+
+		isBasicAuthDisabled, err := memorystore.Provider.GetBoolStoreEnvVariable(constants.EnvKeyDisableBasicAuthentication)
+		if err != nil {
+			log.Debug("Failed to get disable basic authentication value")
+			c.JSON(400, gin.H{"error": "failed to get disable basic authentication value"})
+			return
+		}
+
 		c.HTML(http.StatusOK, "app.tmpl", gin.H{
 			"data": map[string]interface{}{
 				"authorizerURL":    hostname,
@@ -80,6 +88,7 @@ func AppHandler() gin.HandlerFunc {
 				"state":            state,
 				"organizationName": orgName,
 				"organizationLogo": orgLogo,
+				"is_basic_authentication_disabled": isBasicAuthDisabled,
 			},
 		})
 	}


### PR DESCRIPTION
#### What does this PR do?
This PR introduces a mechanism to pass the `DISABLE_BASIC_AUTHENTICATION` environment variable from the backend to the frontend. It then uses this flag to conditionally hide the "Forgot Password" link on the login page. The link will not render if basic authentication is disabled.

#### Which issue(s) does this PR fix?
N/A

#### If this PR affects any API reference documentation, please share the updated endpoint references
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-57a80c22-f253-41ec-843c-cac77e5d3ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57a80c22-f253-41ec-843c-cac77e5d3ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

